### PR TITLE
Fix arg loop condition

### DIFF
--- a/fls/src/main.c
+++ b/fls/src/main.c
@@ -189,7 +189,7 @@ int main(int argc, char* argv[])
 	}
       else
 	{
-	  for (i=1;i<=argc;i++)
+	  for (i=1;i<argc;i++)
 	    {
 	      strcat(buf,argv[i]);
 	      if (i<argc-1)


### PR DESCRIPTION
Loop to process args should have condition i<argc instead of i<=argc