### PR TITLE
Fix loop through args

### DIFF
--- a/nren/src/main.c
+++ b/nren/src/main.c
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
 	goto interactive;
       else
 	{
-	  for (i=1;i<=argc;i++)
+	  for (i=1;i<argc;i++)
 	    {
 	      strcat(buf,argv[i]);
 	      if (i<argc-1)


### PR DESCRIPTION
I missed one of the 'i<=argc' typos in NREN.COM