### PR TITLE
Make tools wait for keypress on DOS 2.0

### DIFF
--- a/fcd/src/main.c
+++ b/fcd/src/main.c
@@ -21,7 +21,7 @@
 unsigned char buf[256];
 unsigned char i=0;
 
-void fcd(unsigned char hs, const char* prefix)
+unsigned char fcd(unsigned char hs, const char* prefix)
 {
   OS.dcb.ddevic=0x70;
   OS.dcb.dunit=1;
@@ -36,8 +36,8 @@ void fcd(unsigned char hs, const char* prefix)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 int main(int argc, char* argv[])
@@ -45,6 +45,7 @@ int main(int argc, char* argv[])
   unsigned char i;
   char *tokens[2];
   unsigned char hs;
+  unsigned char err;
   
   OS.lmargn=2;
   
@@ -72,15 +73,23 @@ int main(int argc, char* argv[])
   if (tokens[0]==NULL)
     {
       print("HOST SLOT REQUIRED\x9b");
-      return(1);
+      err=132;
     }
   else if (hs<1 || hs>8)
     {
       print("INVALID HOST SLOT NUMBER\x9b");
-      return(1);
+      err=160;
+    }
+  else
+    {
+      err=fcd(hs-1,tokens[1]);
     }
 
-  fcd(hs-1,tokens[1]);
+  if (err!=1 && !_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/fconfig/src/main.c
+++ b/fconfig/src/main.c
@@ -55,7 +55,7 @@ void itoa_hex(int val, char *buf)
 /**
  * Read Device Slots
  */
-void adapter_config(void)
+unsigned char adapter_config(void)
 {
   OS.dcb.ddevic=0x70;
   OS.dcb.dunit=1;
@@ -70,8 +70,8 @@ void adapter_config(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 /**
@@ -125,53 +125,56 @@ void print_mac(unsigned char* mac)
  */
 int main(void)
 {
+  unsigned char err=0;
 
   OS.lmargn=2;
   
   // Read adapter config
-  adapter_config();
+  err = adapter_config();
 
-  print("\x9b");
+  if (err==1) {
+    print("\x9b");
 
-  print("           SSID: ");
-  print(adapterConfig.ssid);
-  print("\x9b");
+    print("           SSID: ");
+    print(adapterConfig.ssid);
+    print("\x9b");
 
-  print("       Hostname: ");
-  print(adapterConfig.hostname);
-  print("\x9b");
-  
-  print("     IP Address: ");
-  print_address(adapterConfig.localIP);
-  print("\x9b");
+    print("       Hostname: ");
+    print(adapterConfig.hostname);
+    print("\x9b");
+    
+    print("     IP Address: ");
+    print_address(adapterConfig.localIP);
+    print("\x9b");
 
-  print("Gateway Address: ");
-  print_address(adapterConfig.gateway);
-  print("\x9b");
+    print("Gateway Address: ");
+    print_address(adapterConfig.gateway);
+    print("\x9b");
 
-  print("    DNS Address: ");
-  print_address(adapterConfig.dnsIP);
-  print("\x9b");
-  
-  print("        Netmask: ");
-  print_address(adapterConfig.netmask);
-  print("\x9b");
+    print("    DNS Address: ");
+    print_address(adapterConfig.dnsIP);
+    print("\x9b");
+    
+    print("        Netmask: ");
+    print_address(adapterConfig.netmask);
+    print("\x9b");
 
-  print("    MAC Address: ");
-  print_mac(adapterConfig.macAddress);
-  print("\x9b");
+    print("    MAC Address: ");
+    print_mac(adapterConfig.macAddress);
+    print("\x9b");
 
-  print("          BSSID: ");
-  print_mac(adapterConfig.bssid);
-  print("\x9b");
+    print("          BSSID: ");
+    print_mac(adapterConfig.bssid);
+    print("\x9b");
 
-  print("FCONFIG Version: ");
-  print(FCONFIG_VERSION_FULL);
-  print("\x9b");
+    print("FCONFIG Version: ");
+    print(FCONFIG_VERSION_FULL);
+    print("\x9b");
 
-  print("  Fuji Firmware: ");
-  print(adapterConfig.firmware);
-  print("\x9b");
+    print("  Fuji Firmware: ");
+    print(adapterConfig.firmware);
+    print("\x9b");
+  }
 
   if (!_is_cmdline_dos())
     {
@@ -179,5 +182,5 @@ int main(void)
       get_line(buf,sizeof(buf));
     }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/fcopy/src/main.c
+++ b/fcopy/src/main.c
@@ -25,7 +25,7 @@ unsigned char dest_buf[128];
 unsigned char copy_buf[256];
 unsigned char i=0;
 
-void copy()
+unsigned char copy(void)
 {
   OS.dcb.ddevic=0x70;
   OS.dcb.dunit=1;
@@ -41,8 +41,8 @@ void copy()
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 bool parse_cmdline(char* argv[])
@@ -91,6 +91,7 @@ bool parse_cmdline(char* argv[])
 int main(int argc, char* argv[])
 {
   char tmp[4];
+  unsigned char err=0;
   
   OS.lmargn=2;
 
@@ -128,9 +129,14 @@ int main(int argc, char* argv[])
 
   print("Copying...");
   
-  copy();
+  err=copy();
 
   print("\x9b");
+  if (err!=1 && !_is_cmdline_dos())
+    {
+      print("PRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(linebuf,sizeof(linebuf));
+    }
   
-  return 0;
+  return err==1 ? 0 : err;
 }

--- a/feject/src/main.c
+++ b/feject/src/main.c
@@ -41,6 +41,18 @@ union
 } deviceSlots;
 
 /**
+ * Wait for keypress
+ */
+void pause(void)
+{
+  if (!_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
+}
+
+/**
  * Read host slots
  */
 void host_read(void)
@@ -59,6 +71,7 @@ void host_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -82,6 +95,7 @@ void disk_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -104,6 +118,7 @@ void disk_umount(unsigned char c)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -127,6 +142,7 @@ void disk_write(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -169,6 +185,7 @@ int main(int argc, char* argv[])
   if (s<1 || s>8)
     {
       print("INVALID SLOT NUMBER.\x9b");
+      pause();
       return(1);
     }
   
@@ -198,13 +215,8 @@ int main(int argc, char* argv[])
       s+=0x31;
       printc(&s);
       print(": NOT IN USE\x9b");
+      pause();
     }
 
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }
-  
   return(0);
 }

--- a/fesclk/src/main.c
+++ b/fesclk/src/main.c
@@ -104,5 +104,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
   
-  return(err);
+  return err==1 ? 0 : err;
 }

--- a/fhost/src/main.c
+++ b/fhost/src/main.c
@@ -31,6 +31,18 @@ union
 } hostSlots;
 
 /**
+ * Wait for keypress
+ */
+void pause(void)
+{
+  if (!_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
+}
+
+/**
  * Read host slots
  */
 void host_read(void)
@@ -49,6 +61,7 @@ void host_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -73,6 +86,7 @@ void host_mount(unsigned char c)
       if (OS.dcb.dstats!=1)
 	{
 	  err_sio();
+	  pause();
 	  exit(OS.dcb.dstats);
 	} 
     }
@@ -96,6 +110,7 @@ void host_write(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -158,6 +173,7 @@ int main(int argc, char* argv[])
   if (s<1 || s>8)
     {
       print("INVALID SLOT NUMBER.\x9b");
+      pause();
       return(1);
     }
 
@@ -191,11 +207,6 @@ int main(int argc, char* argv[])
   // Mount server
   host_mount(s);
 
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }
-  
+  pause();
   return(0);
 }

--- a/finfo/src/main.c
+++ b/finfo/src/main.c
@@ -46,7 +46,7 @@ union
 /**
  * Read Device Slots
  */
-void percom_read(unsigned char dunit)
+unsigned char percom_read(unsigned char dunit)
 {
   // Read Drive Tables
   OS.dcb.ddevic=0x31;
@@ -62,8 +62,8 @@ void percom_read(unsigned char dunit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 /**
@@ -218,6 +218,7 @@ void finfo(void)
 int main(int argc, char* argv[])
 {
   unsigned char dunit=0;
+  unsigned char err=0;
 
   OS.lmargn=2;
 
@@ -241,9 +242,10 @@ int main(int argc, char* argv[])
 	dunit=buf[0]-'0';
     }
 
-  percom_read(dunit);
+  err=percom_read(dunit);
 
-  finfo();
+  if (err==1)
+    finfo();
 
   if (!_is_cmdline_dos())
     {
@@ -251,5 +253,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/fld/src/main.c
+++ b/fld/src/main.c
@@ -37,7 +37,7 @@ union
 /**
  * Read Device Slots
  */
-void disk_read(void)
+unsigned char disk_read(void)
 {
   // Read Drive Tables
   OS.dcb.ddevic=0x70;
@@ -53,8 +53,8 @@ void disk_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 /**
@@ -63,41 +63,45 @@ void disk_read(void)
 int main(void)
 {
   unsigned char i=0;
+  unsigned char err=0;
 
   OS.lmargn=2;
   
   // Read in host and device slots from FujiNet
-  disk_read();
+  err=disk_read();
 
-  print("\x9b");
-
-  for (i=0;i<8;i++)
+  if (err==1)
     {
-      unsigned char n=i+0x31;
-      unsigned char hs=deviceSlots.slot[i].hostSlot+0x31;
-      unsigned char m=(deviceSlots.slot[i].mode==0x02 ? 'W' : 'R');
+      print("\x9b");
 
-      if (deviceSlots.slot[i].hostSlot!=0xFF)
-	{
-	  print("D");
-	  printc(&n);
-	  print(": ");
-	  print("(");
-	  printc(&hs);
-	  print(") ");
-	  print("(");
-	  printc(&m);
-	  print(") ");
-	  print(deviceSlots.slot[i].file);
-	  print("\x9b");
-	}
-      else
-	{
-	  print("D");
-	  printc(&n);
-	  print(": ");
-	  print("Empty\x9b");
-	}
+      for (i=0;i<8;i++)
+        {
+          unsigned char n=i+0x31;
+          unsigned char hs=deviceSlots.slot[i].hostSlot+0x31;
+          unsigned char m=(deviceSlots.slot[i].mode==0x02 ? 'W' : 'R');
+
+          if (deviceSlots.slot[i].hostSlot!=0xFF)
+            {
+              print("D");
+              printc(&n);
+              print(": ");
+              print("(");
+              printc(&hs);
+              print(") ");
+              print("(");
+              printc(&m);
+              print(") ");
+              print(deviceSlots.slot[i].file);
+              print("\x9b");
+            }
+          else
+            {
+              print("D");
+              printc(&n);
+              print(": ");
+              print("Empty\x9b");
+            }
+        }
     }
 
   print("\x9b");
@@ -108,5 +112,5 @@ int main(void)
       get_line(buf,sizeof(buf));
     }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/flh/src/main.c
+++ b/flh/src/main.c
@@ -32,7 +32,7 @@ union
 /**
  * Read host slots
  */
-void host_read(void)
+unsigned char host_read(void)
 {
   // Query for host slots
   OS.dcb.ddevic=0x70;
@@ -48,8 +48,8 @@ void host_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 /**
@@ -58,31 +58,35 @@ void host_read(void)
 int main(void)
 {
   unsigned char i=0;
+  unsigned char err=0;
 
   OS.lmargn=2;
   
   // Read in host and device slots from FujiNet
   host_read();
 
-  print("\x9b");
-
-  for (i=0;i<8;i++)
+  if (err==1)
     {
-      unsigned char n=i+0x31;
+      print("\x9b");
 
-      if (hostSlots.host[i][0]!=0x00)
-	{
-	  printc(&n);
-	  print(": ");
-	  print(hostSlots.host[i]);
-	  print("\x9b");
-	}
-      else
-	{
-	  printc(&n);
-	  print(": ");
-	  print("Empty\x9b");
-	}
+      for (i=0;i<8;i++)
+        {
+          unsigned char n=i+0x31;
+
+          if (hostSlots.host[i][0]!=0x00)
+            {
+              printc(&n);
+              print(": ");
+              print(hostSlots.host[i]);
+              print("\x9b");
+            }
+          else
+            {
+              printc(&n);
+              print(": ");
+              print("Empty\x9b");
+            }
+        }
     }
 
   print("\x9b");
@@ -93,5 +97,5 @@ int main(void)
       get_line(buf,sizeof(buf));
     }  
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/fls/src/main.c
+++ b/fls/src/main.c
@@ -30,6 +30,18 @@ union
 } hostSlots;
 
 /**
+ * Wait for keypress
+ */
+void pause(void)
+{
+  if (!_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
+}
+
+/**
  * Read host slots
  */
 void host_read(void)
@@ -48,6 +60,7 @@ void host_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -71,6 +84,7 @@ void host_mount(unsigned char c)
       if (OS.dcb.dstats!=1)
 	{
 	  err_sio();
+	  pause();
 	  exit(OS.dcb.dstats);
 	}
     }
@@ -95,6 +109,7 @@ void directory_open(unsigned char hs, char* b)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -116,6 +131,7 @@ void directory_read(unsigned char hs, unsigned char len)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -137,6 +153,7 @@ void directory_close(unsigned char hs)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -210,6 +227,7 @@ int main(int argc, char* argv[])
   if ((slot<0x31) || (slot>0x38))
     {
       print("INVALID SLOT NUMBER\x9b"); 
+      pause();
       return 1;
     }
 
@@ -220,6 +238,7 @@ int main(int argc, char* argv[])
   if (comma_pos == NULL)
     {
       print("NO COMMA.\x9b");
+      pause();
       return 1;
     }
 
@@ -260,4 +279,5 @@ int main(int argc, char* argv[])
     }
 
   directory_close(slot);
+  pause();
 }

--- a/fmount/src/main.c
+++ b/fmount/src/main.c
@@ -41,6 +41,18 @@ union
 } deviceSlots;
 
 /**
+ * Wait for keypress
+ */
+void pause(void)
+{
+  if (!_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
+}
+
+/**
  * Read host slots
  */
 void host_read(void)
@@ -59,6 +71,7 @@ void host_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -82,6 +95,7 @@ void disk_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -104,6 +118,7 @@ void disk_write(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -127,6 +142,7 @@ void set_filename(char* filename, unsigned char slot)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -150,6 +166,7 @@ void host_mount(unsigned char c)
       if (OS.dcb.dstats!=1)
 	{
 	  err_sio();
+	  pause();
 	  exit(OS.dcb.dstats);
 	}
     }
@@ -173,6 +190,7 @@ void disk_mount(unsigned char c, unsigned char o)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -238,6 +256,7 @@ int main(int argc, char* argv[])
       tokens[3]==NULL)
     {
       print("ALL ARGUMENTS REQUIRED\x9b");
+      pause();
       return(1);
     }
 
@@ -262,6 +281,7 @@ int main(int argc, char* argv[])
   if (ds<1 || ds>8)
     {
       print("INVALID DRIVE SLOT NUMBER\x9b");
+      pause();
       return(1);
     }
 
@@ -271,6 +291,7 @@ int main(int argc, char* argv[])
   if (hs<1 || hs>8)
     {
       print("INVALID HOST SLOT NUMBER\x9b");
+      pause();
       return(1);
     }
 
@@ -287,7 +308,8 @@ int main(int argc, char* argv[])
       break;
     default:
       print("INVALID MODE\x9b");
-      exit(1);
+      pause();
+      return(1);
     }
   
   hs-=1;
@@ -325,11 +347,6 @@ int main(int argc, char* argv[])
   print(tokens[3]);
   print("\x9b\x9b");
 
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }
-  
+  pause();
   return(0);
 }

--- a/fnet/src/main.c
+++ b/fnet/src/main.c
@@ -34,6 +34,18 @@ union
 } netConfig;
 
 /**
+ * Wait for keypress
+ */
+void pause(void)
+{
+  if (!_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
+}
+
+/**
  * main
  */
 int main(int argc, char* argv[])
@@ -76,6 +88,7 @@ int main(int argc, char* argv[])
   if (tokens[0]==NULL)
     {
       print("NETWORK NAME REQUIRED\x9b");
+      pause();
       return(1);
     }
   
@@ -127,11 +140,6 @@ int main(int argc, char* argv[])
 
   OS.soundr=1;
 
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }  
-  
-  return wifiStatus;  
+  pause();
+  return OS.dcb.dstats!=1 ? OS.dcb.dstats : wifiStatus;
 }

--- a/fnew/src/main.c
+++ b/fnew/src/main.c
@@ -54,6 +54,18 @@ union
 } newDisk;
 
 /**
+ * Wait for keypress
+ */
+void pause(void)
+{
+  if (!_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
+}
+
+/**
  * Read host slots
  */
 void host_read(void)
@@ -72,6 +84,7 @@ void host_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -95,6 +108,7 @@ void disk_read(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -117,6 +131,7 @@ void disk_write(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -146,6 +161,7 @@ void disk_create(unsigned short ns, unsigned short ss, unsigned char hs, unsigne
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -169,6 +185,7 @@ void host_mount(unsigned char c)
       if (OS.dcb.dstats!=1)
 	{
 	  err_sio();
+	  pause();
 	  exit(OS.dcb.dstats);
 	}
     }
@@ -192,6 +209,7 @@ void disk_mount(unsigned char c, unsigned char o)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -215,6 +233,7 @@ void set_filename(char* filename, unsigned char slot)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -297,6 +316,7 @@ int main(int argc, char* argv[])
       tokens[3]==NULL)
     {
       print("ALL ARGUMENTS REQUIRED");
+      pause();
       return(1);
     }
 
@@ -309,12 +329,14 @@ int main(int argc, char* argv[])
   if (ds<1 || ds>8)
     {
       print("INVALID DRIVE SLOT NUMBER.\x9b");
+      pause();
       return(1);
     }
 
   if (hs<1 || hs>8)
     {
       print("INVALID HOST SLOT NUMBER.\x9b");
+      pause();
       return(1);
     }
   
@@ -396,11 +418,6 @@ int main(int argc, char* argv[])
   print(tokens[3]);
   print("\x9b");
 
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }  
-  
+  pause();
   return 0;
 }

--- a/freset/src/main.c
+++ b/freset/src/main.c
@@ -21,6 +21,8 @@
 #include "conio.h"
 #include "err.h"
 
+char buf[80];
+
 /**
  * Read Device Slots
  */
@@ -39,6 +41,11 @@ void reset(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      if (!_is_cmdline_dos())
+        {
+          print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+          get_line(buf,sizeof(buf));
+        }
       exit(OS.dcb.dstats);
     }
 }

--- a/fscan/src/main.c
+++ b/fscan/src/main.c
@@ -38,7 +38,7 @@ unsigned char num_networks[4];
 /**
  * Return number of networks
  */
-void scan(void)
+unsigned char scan(void)
 {
   OS.dcb.ddevic=0x70;
   OS.dcb.dunit=1;
@@ -53,14 +53,14 @@ void scan(void)
   if (OS.dcb.dstats!=0x01)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 /**
  * Return Network entry from last scan
  */
-void scan_result(unsigned char n)
+unsigned char scan_result(unsigned char n)
 {
   OS.dcb.ddevic=0x70;
   OS.dcb.dunit=1;
@@ -75,8 +75,8 @@ void scan_result(unsigned char n)
   if (OS.dcb.dstats!=0x01)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 /**
@@ -85,6 +85,7 @@ void scan_result(unsigned char n)
 int main(void)
 {
   unsigned char i=0;
+  unsigned char err=0;
 
   OS.lmargn=2;
   
@@ -93,23 +94,28 @@ int main(void)
   OS.lmargn=2;
   
   print("Scanning...\x9b");
-  scan();
+  err=scan();
 
-  for (i=0;i<num_networks[0];i++)
+  if (err==1)
     {
-      scan_result(i);
-      print("* ");
-      print(ssidInfo.ssid);
-      print("\x9b");
+      for (i=0;i<num_networks[0];i++)
+      {
+        err=scan_result(i);
+        if (err!=1)
+          break;
+        print("* ");
+        print(ssidInfo.ssid);
+        print("\x9b");
+      }
     }
 
   print("\x9b");
 
   if (!_is_cmdline_dos())
     {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      print("PRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
       get_line(buf,sizeof(buf));
     }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/ncd/src/main.c
+++ b/ncd/src/main.c
@@ -23,7 +23,7 @@ unsigned char daux1=0;
 unsigned char daux2=0;
 unsigned char i=0;
 
-void ncd(unsigned char unit)
+unsigned char ncd(unsigned char unit)
 {
   OS.dcb.ddevic=0x71;
   OS.dcb.dunit=unit;
@@ -39,14 +39,15 @@ void ncd(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 int main(int argc, char* argv[])
 {
   unsigned char tmp[2]={0,0};
   unsigned char u=1;
+  unsigned char err=0;
   
   OS.lmargn=2;
   
@@ -83,7 +84,7 @@ int main(int argc, char* argv[])
   else if (buf[2]==':')
     u=buf[1]-0x30;
 
-  ncd(u);
+  err=ncd(u);
 
   if (!_is_cmdline_dos())
     {
@@ -91,5 +92,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/ncopy/src/main.c
+++ b/ncopy/src/main.c
@@ -43,6 +43,8 @@ char buf[8];
 
 int main(int argc, char* argv[])
 {
+  unsigned char err=0;
+
   OS.lmargn=2;
 
   // Args processing.  
@@ -70,11 +72,11 @@ int main(int argc, char* argv[])
     }
 
   if (valid_cio_device(sourceDeviceSpec[0]) && valid_network_device(destDeviceSpec[0]))
-    return copy_d_to_n();
+    err=copy_d_to_n();
   else if (valid_network_device(sourceDeviceSpec[0]) && valid_cio_device(destDeviceSpec[0]))
-    return copy_n_to_d();
+    err=copy_n_to_d();
   else if (valid_network_device(sourceDeviceSpec[0]) && valid_network_device(destDeviceSpec[0]))
-    return copy_n_to_n();
+    err=copy_n_to_n();
 
   if (!_is_cmdline_dos())
     {
@@ -82,4 +84,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
   
+  return err==1 ? 0 : err;
 }

--- a/ndel/src/main.c
+++ b/ndel/src/main.c
@@ -23,7 +23,7 @@ unsigned char daux1=0;
 unsigned char daux2=0;
 unsigned char i=0;
 
-void ndel(unsigned char unit)
+unsigned char ndel(unsigned char unit)
 {
   OS.dcb.ddevic=0x71;
   OS.dcb.dunit=unit;
@@ -39,17 +39,18 @@ void ndel(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 int main(int argc, char* argv[])
 {
   unsigned char tmp[2]={0,0};
   unsigned char u=1;
-  
+  unsigned char err=0;
+
   OS.lmargn=2;
-  
+
   if (_is_cmdline_dos())
     {
       if (argc<2)
@@ -83,13 +84,13 @@ int main(int argc, char* argv[])
   else if (buf[2]==':')
     u=buf[1]-0x30;
 
+  err=ndel(u);
+
   if (!_is_cmdline_dos())
     {
       print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
       get_line(buf,sizeof(buf));
     }
-  
-  ndel(u);
-  
-  return(0);
+
+  return err==1 ? 0 : err;
 }

--- a/ndir/src/main.c
+++ b/ndir/src/main.c
@@ -23,6 +23,18 @@ unsigned char daux1=0;
 unsigned char daux2=0;
 unsigned char i=0;
 
+/**
+ * Wait for keypress
+ */
+void pause(void)
+{
+  if (!_is_cmdline_dos())
+    {
+      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+      get_line(buf,sizeof(buf));
+    }
+}
+
 void nopen(unsigned char unit)
 {
   OS.dcb.ddevic=0x71;
@@ -39,6 +51,7 @@ void nopen(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -59,6 +72,7 @@ void nclose(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -79,6 +93,7 @@ void nread(unsigned char unit, unsigned short len)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -99,6 +114,7 @@ void nstatus(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      pause();
       exit(OS.dcb.dstats);
     }
 }
@@ -165,11 +181,7 @@ int main(int argc, char* argv[])
 
   nclose(u);
 
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }
+  pause();
   
   return(0);
 }

--- a/nlogin/src/main.c
+++ b/nlogin/src/main.c
@@ -21,7 +21,7 @@
 unsigned char i=0;
 char buf[8];
 
-void nlogin(unsigned char unit, char *login, char *password)
+unsigned char nlogin(unsigned char unit, char *login, char *password)
 {
   OS.dcb.ddevic=0x71;
   OS.dcb.dunit=unit;
@@ -36,7 +36,7 @@ void nlogin(unsigned char unit, char *login, char *password)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
+      return OS.dcb.dstats;
     }
 
   OS.dcb.dcomnd=0xFE;
@@ -47,8 +47,10 @@ void nlogin(unsigned char unit, char *login, char *password)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
+      return OS.dcb.dstats;
     }
+
+  return 0;
 }
 
 void opts(char* argv0)
@@ -63,6 +65,7 @@ int main(int argc, char* argv[])
   char *login;
   char *password;
   unsigned char u=1;
+  unsigned char err=0;
   
   OS.lmargn=2;
   
@@ -101,20 +104,17 @@ int main(int argc, char* argv[])
   else if (deviceSpec[2]==':')
     u=deviceSpec[1]-0x30;
 
-  nlogin(u,login,password);
+  err=nlogin(u,login,password);
 
   if (!_is_cmdline_dos())
     {
       free(deviceSpec);
       free(login);
       free(password);
-    }
 
-  if (!_is_cmdline_dos())
-    {
       print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
       get_line(buf,sizeof(buf));
     }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/nmkdir/src/main.c
+++ b/nmkdir/src/main.c
@@ -23,7 +23,7 @@ unsigned char daux1=0;
 unsigned char daux2=0;
 unsigned char i=0;
 
-void nmkdir(unsigned char unit)
+unsigned char nmkdir(unsigned char unit)
 {
   OS.dcb.ddevic=0x71;
   OS.dcb.dunit=unit;
@@ -39,14 +39,15 @@ void nmkdir(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 int main(int argc, char* argv[])
 {
   unsigned char tmp[2]={0,0};
   unsigned char u=1;
+  unsigned char err=0;
   
   OS.lmargn=2;
   
@@ -83,7 +84,7 @@ int main(int argc, char* argv[])
   else if (buf[2]==':')
     u=buf[1]-0x30;
 
-  nmkdir(u);
+  err=nmkdir(u);
 
   if (!_is_cmdline_dos())
     {
@@ -91,5 +92,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
 
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/npwd/src/main.c
+++ b/npwd/src/main.c
@@ -21,7 +21,7 @@
 unsigned char buf[256];
 unsigned char unit;
 
-void npwd(void)
+unsigned char npwd(void)
 {
   OS.dcb.ddevic=0x71;
   OS.dcb.dunit=unit;
@@ -37,12 +37,14 @@ void npwd(void)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
-      exit(OS.dcb.dstats);
     }
+  return OS.dcb.dstats;
 }
 
 int main(int argc, char* argv[])
 {  
+  unsigned char err=0;
+
   OS.lmargn=2;
 
   if (argc<2)
@@ -54,7 +56,7 @@ int main(int argc, char* argv[])
   else
     unit=1;
   
-  npwd();
+  err=npwd();
   
   if (buf[0]==0x00)
     print("NO PREFIX SET.\x9b");
@@ -69,5 +71,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
   
-  return(0);
+  return err==1 ? 0 : err;
 }

--- a/nren/src/main.c
+++ b/nren/src/main.c
@@ -39,6 +39,11 @@ void nren(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      if (!_is_cmdline_dos())
+        {
+          print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+          get_line(buf,sizeof(buf));
+        }
       exit(OS.dcb.dstats);
     }
 }
@@ -84,12 +89,6 @@ int main(int argc, char* argv[])
     u=buf[1]-0x30;
 
   nren(u);
-
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }
   
   return(0);
 }

--- a/nrmdir/src/main.c
+++ b/nrmdir/src/main.c
@@ -39,6 +39,11 @@ void nrmdir(unsigned char unit)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      if (!_is_cmdline_dos())
+        {
+          print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+          get_line(buf,sizeof(buf));
+        }
       exit(OS.dcb.dstats);
     }
 }
@@ -84,12 +89,6 @@ int main(int argc, char* argv[])
     u=buf[1]-0x30;
 
   nrmdir(u);
-
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }
   
   return(0);
 }

--- a/ntrans/src/main.c
+++ b/ntrans/src/main.c
@@ -38,6 +38,11 @@ void ntrans(unsigned char unit, unsigned char mode)
   if (OS.dcb.dstats!=1)
     {
       err_sio();
+      if (!_is_cmdline_dos())
+        {
+          print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
+          get_line(buf,sizeof(buf));
+        }
       exit(OS.dcb.dstats);
     }
 }
@@ -91,11 +96,5 @@ int main(int argc, char* argv[])
 
   ntrans(u,m);
 
-  if (!_is_cmdline_dos())
-    {
-      print("\x9bPRESS \xD2\xC5\xD4\xD5\xD2\xCE TO CONTINUE.\x9b");
-      get_line(buf,sizeof(buf));
-    }
-  
   return(0);
 }

--- a/rautoans/src/main.c
+++ b/rautoans/src/main.c
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
 	}
     }
   
-  auto_ans(o);
+  err=auto_ans(o);
   
   if (!_is_cmdline_dos())
     {
@@ -94,5 +94,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
   
-  return(err);
+  return(err != 1);
 }

--- a/rlisten/src/main.c
+++ b/rlisten/src/main.c
@@ -86,10 +86,11 @@ int main(int argc, char* argv[])
   if (port<1)
     {
       print("INVALID PORT NUMBER.\x9b");
-      return(1);
+      err=1;
     }
 
-  err=listen_port(port);
+  if (!err)
+    err=listen_port(port);
   
   if (!_is_cmdline_dos())
     {
@@ -97,5 +98,5 @@ int main(int argc, char* argv[])
       get_line(buf,sizeof(buf));
     }
   
-  return(err);
+  return err==1 ? 0 : err;
 }


### PR DESCRIPTION
Non-command line DOSes like Atari DOS 2.x and MyDOS redraw the screen
immediately when a program exits.  Make sure there's a "press RETURN"
prompt before exiting if a program has displayed useful information,
such as an error message.